### PR TITLE
feat: add options to leanwuzla for debugging behaviour

### DIFF
--- a/Leanwuzla/Options.lean
+++ b/Leanwuzla/Options.lean
@@ -10,18 +10,18 @@ import Lean
 open Lean
 
 
-register_option bitwuzla.ac_nf : Bool := {
+register_option leanwuzla.ac_nf : Bool := {
   defValue := false
   descr := "Enable running 'ac_nf' before the goal"
 }
 
-register_option bitwuzla.simp_ac : Bool := {
+register_option leanwuzla.simp_ac : Bool := {
   defValue := false
   descr := "Enable simplifying upto associativity commutativity by running a `simp` set."
 }
 
-register_option bitwuzla.admit : Bool := {
-  defValue := true
+register_option leanwuzla.admit : Bool := {
+  defValue := false
   descr := "Enable admitting the goal without running `bv_decide`"
 }
 

--- a/Leanwuzla/Options.lean
+++ b/Leanwuzla/Options.lean
@@ -1,0 +1,28 @@
+/-
+This file registers options that can be passed with `-D <option-name>=<value>`,
+which are added to the global options environment.
+
+These options are used to configure Leanwuzla behaviour.
+
+Authors: Siddharth Bhat
+-/
+import Lean
+open Lean
+
+
+register_option bitwuzla.ac_nf : Bool := {
+  defValue := false
+  descr := "Enable running 'ac_nf' before the goal"
+}
+
+register_option bitwuzla.simp_ac : Bool := {
+  defValue := false
+  descr := "Enable simplifying upto associativity commutativity by running a `simp` set."
+}
+
+register_option bitwuzla.admit : Bool := {
+  defValue := true
+  descr := "Enable admitting the goal without running `bv_decide`"
+}
+
+

--- a/Main.lean
+++ b/Main.lean
@@ -44,16 +44,18 @@ def decide (type : Expr) : MetaM Unit := do
     mv'.withContext $ IO.FS.withTempFile fun _ lratFile => do
       let mut mv' := mv'
       let startTime ← IO.monoMsNow
-      let cfg ← (Tactic.BVDecide.Frontend.TacticContext.new lratFile).run' { declName? := `lrat }
 
-      if bitwuzla.ac_nf.get (← getOptions) then
-        logInfo "running ac_nf on goal"
+      if leanwuzla.ac_nf.get (← getOptions) then
+        IO.println "running ac_nf on goal..."
         mv' ← AC.rewriteUnnormalized mv'
+        IO.println "ac_nf finished running."
 
-      if bitwuzla.admit.get (← getOptions)  then 
-        logInfo "admitting goal"
+      if leanwuzla.admit.get (← getOptions)  then 
+        IO.println "admitting goal"
         mv'.admit
       else
+        IO.println "proving goal with bv_decide."
+        let cfg ← (Tactic.BVDecide.Frontend.TacticContext.new lratFile).run' { declName? := `lrat }
         discard <| Tactic.BVDecide.Frontend.bvDecide mv' cfg
       let endTime ← IO.monoMsNow
       logInfo m!"bv_decide took {endTime - startTime}ms"


### PR DESCRIPTION
We use the option setting machinery to expose options as `leanwuzla.*`,
which we use to change the behaviour of the executable.

- `-D leanwuzla.ac_nf=True` runs `ac_nf` on the goal state as preprocessing.
- `-D leanwuzla.admit=True` closes the goal immediately with a `sorry`.

---

We are using these to debug LeanSAT's performance on the SMT-LIB-2 benchmark of `jain_2_true.c.21.smt2`

---

In particular, the following (turning on `ac_nf`, while admitting the goal, times out in `ac_nf`):

```lean
lake exe leanwuzla -D maxHeartbeats=0 \
  -D trace.profiler=true \
  -D trace.Meta.Tactic.bv=true \
  -D trace.Meta.Tactic.sat=true \
   -D trace.profiler.threshold=1 \
   -D maxRecDepth=9999999999999999999 \
   -D leanwuzla.admit=true -D \
   leanwuzla.ac_nf=true \
   /Users/bollu/Downloads/jain_21_7.smt2
```